### PR TITLE
Fix: regexp keeps '=' characters in result Base64.

### DIFF
--- a/www/chooser.js
+++ b/www/chooser.js
@@ -67,7 +67,7 @@ function getFileInternal (
 
 					if (includeData) {
 						var base64Data = o.data.replace(
-							/[^A-Za-z0-9\+\/]/g,
+							/[^A-Za-z0-9\+\/=]/g,
 							''
 						);
 


### PR DESCRIPTION
- Fix Base64 padding being removed before returning the plugin result.
